### PR TITLE
wait rather than check for CPU goodness

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -26,8 +26,6 @@ def play_game(player, entities, game_map, message_log, game_state, con, panel, c
     targeting_item = None
 
     while not libtcod.console_is_window_closed():
-        libtcod.sys_check_for_event(libtcod.EVENT_KEY_PRESS | libtcod.EVENT_MOUSE, key, mouse)
-
         if fov_recompute:
             recompute_fov(fov_map, player.x, player.y, constants['fov_radius'], constants['fov_light_walls'],
                           constants['fov_algorithm'])
@@ -38,10 +36,10 @@ def play_game(player, entities, game_map, message_log, game_state, con, panel, c
 
         fov_recompute = False
 
-        libtcod.console_flush()
-
         clear_all(con, entities)
 
+        libtcod.console_flush()
+        libtcod.sys_wait_for_event(libtcod.EVENT_KEY_PRESS | libtcod.EVENT_MOUSE, key, mouse, True)
         action = handle_keys(key, game_state)
         mouse_action = handle_mouse(mouse)
 


### PR DESCRIPTION
This changes `sys_check_for_event` to `sys_wait_for_event`, which makes it blocking rather than having the while loop handle the waiting. On my Linux system, using check leads to bogus keypresses being registered (moves two spaces in some circumstances), and 100% CPU usage at all times. As far as I can tell, it works fine with this change, including mouse functionality.

Also, thanks for making the Python 3 version of the tutorial! It's been fun to tinker with.